### PR TITLE
feat: Implement user profile page and UI enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,3 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
-
-# Gemini specific files
-gemini.md
-apiDoc.json

--- a/apiDoc.json
+++ b/apiDoc.json
@@ -1,0 +1,1175 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "默认模块",
+    "description": "",
+    "version": "1.0.0"
+  },
+  "tags": [],
+  "paths": {
+    "/api/v1/users/profile": {
+      "get": {
+        "summary": "getUserProfile",
+        "deprecated": false,
+        "description": "- 返回用户信息",
+        "tags": [],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "用于用户身份认证的令牌。格式为 `Bearer <token>`，其中 `<token>` 是从登录或注册接口返回的 `accessToken`。所有受保护的接口都必须携带此请求头。",
+            "required": true,
+            "example": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiMTIzNDU2IiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserProfile"
+                }
+              }
+            },
+            "headers": {}
+          },
+          "401": {
+            "$ref": "#/components/responses/未认证",
+            "description": ""
+          },
+          "403": {
+            "$ref": "#/components/responses/权限不足",
+            "description": ""
+          },
+          "404": {
+            "$ref": "#/components/responses/未找到",
+            "description": ""
+          },
+          "500": {
+            "$ref": "#/components/responses/服务器内部错误",
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "phenix_token": []
+          }
+        ]
+      },
+      "patch": {
+        "summary": "updateUserProfile",
+        "deprecated": false,
+        "description": "",
+        "tags": [],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "用于用户身份认证的令牌。格式为 `Bearer <token>`，其中 `<token>` 是从登录或注册接口返回的 `accessToken`。所有受保护的接口都必须携带此请求头。",
+            "required": true,
+            "example": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiMTIzNDU2IiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "username": {
+                    "type": "string",
+                    "title": "用户名",
+                    "description": "若没有，则返回null"
+                  },
+                  "email": {
+                    "type": "string",
+                    "title": "邮箱",
+                    "description": "若没有，则返回null"
+                  },
+                  "avatar": {
+                    "type": "string",
+                    "title": "头像",
+                    "description": "若没有，则返回null"
+                  }
+                }
+              },
+              "examples": {}
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserProfile"
+                }
+              }
+            },
+            "headers": {}
+          },
+          "401": {
+            "$ref": "#/components/responses/未认证",
+            "description": ""
+          },
+          "403": {
+            "$ref": "#/components/responses/权限不足",
+            "description": ""
+          },
+          "404": {
+            "$ref": "#/components/responses/未找到",
+            "description": ""
+          },
+          "500": {
+            "$ref": "#/components/responses/服务器内部错误",
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "phenix_token": []
+          }
+        ]
+      }
+    },
+    "/api/v1/users/change-password": {
+      "patch": {
+        "summary": "changePassword",
+        "deprecated": false,
+        "description": "",
+        "tags": [],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "用于用户身份认证的令牌。格式为 `Bearer <token>`，其中 `<token>` 是从登录或注册接口返回的 `accessToken`。所有受保护的接口都必须携带此请求头。",
+            "required": true,
+            "example": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiMTIzNDU2IiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChangePasswordPayload"
+              },
+              "examples": {}
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserProfile"
+                }
+              }
+            },
+            "headers": {}
+          },
+          "401": {
+            "$ref": "#/components/responses/未认证",
+            "description": ""
+          },
+          "403": {
+            "$ref": "#/components/responses/权限不足",
+            "description": ""
+          },
+          "404": {
+            "$ref": "#/components/responses/未找到",
+            "description": ""
+          },
+          "500": {
+            "$ref": "#/components/responses/服务器内部错误",
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "phenix_token": []
+          }
+        ]
+      }
+    },
+    "/api/v1/auth/register": {
+      "post": {
+        "summary": "register",
+        "deprecated": false,
+        "description": "",
+        "tags": [],
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterPayload"
+              },
+              "examples": {}
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserProfile"
+                }
+              }
+            },
+            "headers": {}
+          },
+          "401": {
+            "$ref": "#/components/responses/未认证",
+            "description": ""
+          },
+          "403": {
+            "$ref": "#/components/responses/权限不足",
+            "description": ""
+          },
+          "404": {
+            "$ref": "#/components/responses/未找到",
+            "description": ""
+          },
+          "500": {
+            "$ref": "#/components/responses/服务器内部错误",
+            "description": ""
+          }
+        },
+        "security": []
+      }
+    },
+    "/api/v1/auth/login": {
+      "post": {
+        "summary": "login",
+        "deprecated": false,
+        "description": "",
+        "tags": [],
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/PasswordLoginPayload"
+                  },
+                  {
+                    "$ref": "#/components/schemas/EmailCodeLoginPayload"
+                  }
+                ]
+              },
+              "examples": {}
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthSuccessResponse"
+                }
+              }
+            },
+            "headers": {}
+          },
+          "401": {
+            "$ref": "#/components/responses/未认证",
+            "description": ""
+          },
+          "403": {
+            "$ref": "#/components/responses/权限不足",
+            "description": ""
+          },
+          "404": {
+            "$ref": "#/components/responses/未找到",
+            "description": ""
+          },
+          "500": {
+            "$ref": "#/components/responses/服务器内部错误",
+            "description": ""
+          }
+        },
+        "security": []
+      }
+    },
+    "/api/v1/auth/refreshToken": {
+      "post": {
+        "summary": "refreshToken",
+        "deprecated": false,
+        "description": "",
+        "tags": [],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "",
+            "required": false,
+            "example": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiMTIzNDU2IiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RefreshTokenPayload"
+              },
+              "example": {
+                "refreshToken": "eyJhbGciOiJIUzI1NiJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaF90b2tlbiIsInN1YiI6ImsxemdncTM4IiwiaWF0IjoxNzY0NTc1Nzc3LCJleHAiOjE3NjcxNjc3Nzd9.k8UIx8WSsu1OXtBrHH6D_fiibQYBZUqo6WUX3-1awcY"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RefreshTokenResponse"
+                }
+              }
+            },
+            "headers": {}
+          },
+          "401": {
+            "$ref": "#/components/responses/未认证",
+            "description": ""
+          },
+          "403": {
+            "$ref": "#/components/responses/权限不足",
+            "description": ""
+          },
+          "404": {
+            "$ref": "#/components/responses/未找到",
+            "description": ""
+          },
+          "500": {
+            "$ref": "#/components/responses/服务器内部错误",
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "phenix_token": []
+          }
+        ]
+      }
+    },
+    "/api/v1/auth/logout": {
+      "post": {
+        "summary": "logout",
+        "deprecated": false,
+        "description": "",
+        "tags": [],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "",
+            "required": false,
+            "example": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiMTIzNDU2IiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LogoutPayload"
+              },
+              "examples": {}
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {}
+                }
+              }
+            },
+            "headers": {}
+          },
+          "401": {
+            "$ref": "#/components/responses/未认证",
+            "description": ""
+          },
+          "403": {
+            "$ref": "#/components/responses/权限不足",
+            "description": ""
+          },
+          "404": {
+            "$ref": "#/components/responses/未找到",
+            "description": ""
+          },
+          "500": {
+            "$ref": "#/components/responses/服务器内部错误",
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "phenix_token": []
+          }
+        ]
+      }
+    },
+    "/api/v1/products": {
+      "get": {
+        "summary": "getProductsList",
+        "deprecated": false,
+        "description": "",
+        "tags": [],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Product"
+                  },
+                  "minItems": 0,
+                  "uniqueItems": true
+                }
+              }
+            },
+            "headers": {}
+          },
+          "401": {
+            "$ref": "#/components/responses/未认证",
+            "description": ""
+          },
+          "403": {
+            "$ref": "#/components/responses/权限不足",
+            "description": ""
+          },
+          "404": {
+            "$ref": "#/components/responses/未找到",
+            "description": ""
+          },
+          "500": {
+            "$ref": "#/components/responses/服务器内部错误",
+            "description": ""
+          }
+        },
+        "security": []
+      },
+      "post": {
+        "summary": "createProduct",
+        "deprecated": false,
+        "description": "",
+        "tags": [],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "",
+            "required": false,
+            "example": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiMTIzNDU2IiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateProductPayload"
+              },
+              "examples": {}
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Product"
+                }
+              }
+            },
+            "headers": {}
+          },
+          "401": {
+            "$ref": "#/components/responses/未认证",
+            "description": ""
+          },
+          "403": {
+            "$ref": "#/components/responses/权限不足",
+            "description": ""
+          },
+          "404": {
+            "$ref": "#/components/responses/未找到",
+            "description": ""
+          },
+          "500": {
+            "$ref": "#/components/responses/服务器内部错误",
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "phenix_token": []
+          }
+        ]
+      }
+    },
+    "/api/v1/products/{product_id}": {
+      "get": {
+        "summary": "getProductById",
+        "deprecated": false,
+        "description": "",
+        "tags": [],
+        "parameters": [
+          {
+            "name": "product_id",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Product"
+                }
+              }
+            },
+            "headers": {}
+          },
+          "401": {
+            "$ref": "#/components/responses/未认证",
+            "description": ""
+          },
+          "403": {
+            "$ref": "#/components/responses/权限不足",
+            "description": ""
+          },
+          "404": {
+            "$ref": "#/components/responses/未找到",
+            "description": ""
+          },
+          "500": {
+            "$ref": "#/components/responses/服务器内部错误",
+            "description": ""
+          }
+        },
+        "security": []
+      },
+      "patch": {
+        "summary": "updateProduct",
+        "deprecated": false,
+        "description": "",
+        "tags": [],
+        "parameters": [
+          {
+            "name": "product_id",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "",
+            "required": false,
+            "example": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiMTIzNDU2IiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateProductPayload"
+              },
+              "examples": {}
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Product"
+                }
+              }
+            },
+            "headers": {}
+          },
+          "401": {
+            "$ref": "#/components/responses/未认证",
+            "description": ""
+          },
+          "403": {
+            "$ref": "#/components/responses/权限不足",
+            "description": ""
+          },
+          "404": {
+            "$ref": "#/components/responses/未找到",
+            "description": ""
+          },
+          "500": {
+            "$ref": "#/components/responses/服务器内部错误",
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "phenix_token": []
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "UserProfile": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "title": "用户ID"
+          },
+          "role": {
+            "type": "string",
+            "title": "用户权限",
+            "description": "用户user，管理员admin"
+          },
+          "username": {
+            "type": "string",
+            "title": "用户名"
+          },
+          "avatar": {
+            "type": "string",
+            "title": "头像",
+            "description": "若无头像，后端返回null"
+          },
+          "email": {
+            "type": "string",
+            "title": "邮箱"
+          },
+          "address": {
+            "type": "string",
+            "title": "地址",
+            "description": "若无地址，后端返回null"
+          },
+          "createdAt": {
+            "type": "string",
+            "title": "创建时间",
+            "description": "24小时，年月日--时分秒"
+          },
+          "updatedAt": {
+            "type": "string",
+            "title": "更新时间",
+            "description": "24小时，年月日--时分秒"
+          }
+        },
+        "required": [
+          "userId",
+          "username",
+          "email",
+          "createdAt",
+          "updatedAt",
+          "role"
+        ]
+      },
+      "UpdateProfilePayload": {
+        "type": "object",
+        "properties": {
+          "username": {
+            "type": "string",
+            "title": "用户名",
+            "description": "若无，则提交null"
+          },
+          "email": {
+            "type": "string",
+            "title": "邮箱",
+            "description": "若无，则提交null"
+          },
+          "avatar": {
+            "type": "string",
+            "title": "头像",
+            "description": "若无，则提交null"
+          }
+        }
+      },
+      "ChangePasswordPayload": {
+        "type": "object",
+        "properties": {
+          "oldPassword": {
+            "type": "string",
+            "title": "旧密码"
+          },
+          "newPassword": {
+            "type": "string",
+            "title": "新密码"
+          }
+        },
+        "required": [
+          "oldPassword",
+          "newPassword"
+        ]
+      },
+      "PasswordLoginPayload": {
+        "type": "object",
+        "properties": {
+          "loginType": {
+            "type": "string",
+            "title": "登录方式"
+          },
+          "email": {
+            "type": "string",
+            "title": "邮箱"
+          },
+          "password": {
+            "type": "string",
+            "title": "密码"
+          }
+        },
+        "required": [
+          "email",
+          "password",
+          "loginType"
+        ]
+      },
+      "EmailCodeLoginPayload": {
+        "type": "object",
+        "properties": {
+          "loginType": {
+            "type": "string",
+            "title": "登录方式"
+          },
+          "email": {
+            "type": "string",
+            "title": "邮箱"
+          },
+          "code": {
+            "type": "string",
+            "title": "验证码"
+          }
+        },
+        "required": [
+          "email",
+          "code",
+          "loginType"
+        ]
+      },
+      "AuthSuccessResponse": {
+        "type": "object",
+        "properties": {
+          "user": {
+            "$ref": "#/components/schemas/UserProfile"
+          },
+          "tokens": {
+            "type": "object",
+            "properties": {
+              "accessToken": {
+                "type": "string"
+              },
+              "refreshToken": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "accessToken",
+              "refreshToken"
+            ]
+          }
+        },
+        "required": [
+          "user",
+          "tokens"
+        ]
+      },
+      "RegisterPayload": {
+        "type": "object",
+        "properties": {
+          "username": {
+            "type": "string",
+            "title": "用户名"
+          },
+          "email": {
+            "type": "string",
+            "title": "邮箱"
+          },
+          "password": {
+            "type": "string",
+            "title": "密码"
+          },
+          "code": {
+            "type": "string",
+            "title": "验证码"
+          }
+        },
+        "required": [
+          "username",
+          "email",
+          "password",
+          "code"
+        ]
+      },
+      "RefreshTokenPayload": {
+        "type": "object",
+        "properties": {
+          "refreshToken": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "refreshToken"
+        ]
+      },
+      "RefreshTokenResponse": {
+        "type": "object",
+        "properties": {
+          "refreshToken": {
+            "type": "string"
+          },
+          "accessToken": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "refreshToken",
+          "accessToken"
+        ]
+      },
+      "LogoutPayload": {
+        "type": "object",
+        "properties": {
+          "refreshToken": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "refreshToken"
+        ]
+      },
+      "Product": {
+        "type": "object",
+        "properties": {
+          "productId": {
+            "type": "string",
+            "title": "商品ID"
+          },
+          "name": {
+            "type": "string",
+            "title": "商品名"
+          },
+          "price": {
+            "type": "number",
+            "title": "商品价格"
+          },
+          "description": {
+            "type": "string",
+            "title": "商品描述"
+          },
+          "stock": {
+            "type": "number",
+            "title": "库存"
+          },
+          "category": {
+            "type": "string",
+            "title": "商品类别"
+          },
+          "imageUrl": {
+            "type": "string",
+            "title": "商品图片"
+          },
+          "createdAt": {
+            "type": "string",
+            "title": "创建时间"
+          },
+          "updatedAt": {
+            "type": "string",
+            "title": "更新时间"
+          }
+        },
+        "required": [
+          "productId",
+          "name",
+          "price",
+          "description",
+          "imageUrl",
+          "stock",
+          "createdAt",
+          "updatedAt",
+          "category"
+        ]
+      },
+      "CreateProductPayload": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "商品名称"
+          },
+          "price": {
+            "type": "number",
+            "title": "商品价格",
+            "description": "若无，则返回null"
+          },
+          "description": {
+            "type": "string",
+            "title": "商品描述",
+            "description": "若无，则返回null"
+          },
+          "stock": {
+            "type": "number",
+            "title": "库存",
+            "description": "若无，则返回null"
+          },
+          "imageUrl": {
+            "type": "string",
+            "title": "商品图片",
+            "description": "若无，则返回null"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "UpdateProductPayload": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "商品名称",
+            "description": "若无，则提交null"
+          },
+          "description": {
+            "type": "string",
+            "title": "商品描述",
+            "description": "若无，则提交null"
+          },
+          "category": {
+            "type": "string",
+            "title": "商品类别",
+            "description": "若无，则提交null"
+          },
+          "price": {
+            "type": "number",
+            "title": "商品价格",
+            "description": "若无，则提交null"
+          },
+          "stock": {
+            "type": "number",
+            "title": "库存",
+            "description": "若无，则提交null"
+          },
+          "imageUrl": {
+            "type": "string",
+            "title": "图片",
+            "description": "若无，则提交null"
+          }
+        }
+      },
+      "ApiArror": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "title": "错误消息"
+          },
+          "code": {
+            "type": "string",
+            "title": "机器码"
+          },
+          "status": {
+            "type": "string",
+            "title": "错误码"
+          }
+        },
+        "required": [
+          "message",
+          "code",
+          "status"
+        ]
+      }
+    },
+    "responses": {
+      "未认证": {
+        "description": "",
+        "content": {
+          "application/json": {
+            "schema": {
+              "title": "",
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "title": "错误信息"
+                },
+                "status": {
+                  "type": "string",
+                  "title": "错误码"
+                },
+                "code": {
+                  "type": "string",
+                  "title": "机器码"
+                }
+              },
+              "required": [
+                "message",
+                "status",
+                "code"
+              ]
+            }
+          }
+        }
+      },
+      "未找到": {
+        "description": "",
+        "content": {
+          "application/json": {
+            "schema": {
+              "title": "",
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "title": "错误信息"
+                },
+                "status": {
+                  "type": "string",
+                  "title": "错误码"
+                },
+                "code": {
+                  "type": "string",
+                  "title": "机器码"
+                }
+              },
+              "required": [
+                "status",
+                "code",
+                "message"
+              ]
+            }
+          }
+        }
+      },
+      "权限不足": {
+        "description": "",
+        "content": {
+          "application/json": {
+            "schema": {
+              "title": "",
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "title": "错误信息"
+                },
+                "code": {
+                  "type": "string",
+                  "title": "机器码"
+                },
+                "status": {
+                  "type": "string",
+                  "title": "错误码"
+                }
+              },
+              "required": [
+                "message",
+                "code",
+                "status"
+              ]
+            }
+          }
+        }
+      },
+      "服务器内部错误": {
+        "description": "",
+        "content": {
+          "application/json": {
+            "schema": {
+              "title": "",
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "title": "错误信息"
+                },
+                "code": {
+                  "type": "string",
+                  "title": "机器码"
+                },
+                "status": {
+                  "type": "string",
+                  "title": "错误码"
+                }
+              },
+              "required": [
+                "message",
+                "code",
+                "status"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "phenix_token": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    }
+  },
+  "servers": [],
+  "security": []
+}

--- a/gemini.md
+++ b/gemini.md
@@ -1,0 +1,127 @@
+# 项目概览
+
+- **项目名称**：Phoenix (凤凰商城)
+- **业务场景**：一个基于现代前端技术栈构建的电商应用，包含前台商城（主页、购物车、商家页）与后台管理功能。
+- **技术栈**：
+  - **核心框架**：React 19 + TypeScript + Vite
+  - **路由**：React Router v7
+  - **样式方案**：Tailwind CSS v4 (使用 CSS 变量与 `@theme inline` 配置) + `clsx` + `tailwind-merge`
+  - **UI 组件库**：Radix UI Primitives (Headless UI) + Shadcn UI 风格封装 + Lucide React (图标)
+  - **网络请求**：Axios (封装在 `src/services/apiClient.ts`，含拦截器与统一错误处理)
+  - **代码规范**：ESLint (Flat Config) + Prettier
+
+# 你的角色与回答风格
+
+- **角色设定**：你是一名为 `Phoenix` 项目服务的资深前端架构师及代码审查员。你对 React 19 新特性、TypeScript 高级类型以及 Tailwind CSS v4 有深入理解。
+- **语言要求**：默认使用**简体中文**回答，专业术语（如 Hook, Component, Prop, Interface）可保留英文。
+- **回答原则**：
+  - **准确性优先**：生成代码前，先基于上下文理解现有的类型定义 (`src/types/`) 和服务层 (`src/services/`)，避免重复造轮子。
+  - **简洁且具体**：先给出结论或修改计划，再提供代码。代码必须包含文件路径注释。
+  - **安全性**：涉及删除文件、修改配置或大规模重构时，必须先列出计划并请求确认。
+
+# 代码与工程规范
+
+## 1. 代码风格与命名
+
+- **组件**：使用函数式组件 (`function ComponentName() {}`)，优先使用 TypeScript 接口 (`interface`) 定义 Props。
+- **命名**：
+  - 组件/接口/类型：`PascalCase` (如 `UserProfile`, `MerchantPage`)。
+  - 变量/函数/Hook：`camelCase` (如 `useAuth`, `fetchProductList`)。
+  - 常量：`UPPER_SNAKE_CASE` (如 `API_BASE_URL`)。
+- **路径别名**：强制使用 `@/` 来引用 `src/` 下的模块（如 `import { Button } from "@/components/ui/button"`）。
+
+## 2. UI 与样式开发 (Tailwind v4)
+
+- **原子化优先**：仅在必要时编写自定义 CSS，优先使用 Tailwind 工具类。
+- **样式合并**：必须使用 `src/lib/utils.ts` 中的 `cn()` 函数来合并 className，以支持 Shadcn UI 的样式覆盖机制。
+  - ✅ 正确：`className={cn("bg-primary text-primary-foreground", className)}`
+  - ❌ 错误：`className={`bg-primary ${className}`}`
+- **组件复用**：
+  - **基础组件**：严禁直接写原生 HTML 标签（如 `<button>`），必须复用 `src/components/ui/` 下的组件（如 `Button`, `Input`, `Card`）。
+  - **图标**：使用 `lucide-react`。
+
+## 3. 状态管理与 API 交互
+
+- **Service 层模式**：
+  - 所有 API 请求必须封装在 `src/services/` 目录下（如 `auth.ts`, `product.ts`）。
+  - 禁止在组件内部直接调用 `axios.get`，必须调用 Service 函数。
+  - Service 函数应返回 `Promise<DataType>`，错误处理交由 `apiClient` 拦截器或组件层的 `try-catch` 处理。
+- **类型定义**：
+  - API 的请求参数 (Payload) 和响应数据 (Response) 必须在 `src/types/` 中定义接口。
+  - 避免使用 `any`，利用 TypeScript 的推断能力。
+
+## 4. React 19 与 路由
+
+- **路由**：使用 React Router v7 的组件（`Routes`, `Route`, `Link`, `useNavigate`）。
+- **Hooks**：遵循 Hooks 规则，确保依赖项正确。
+
+# 常见任务流程
+
+## 任务 A：实现新功能 (Feature)
+
+1. **分析需求**：确定需要复用的 UI 组件（Button, Card 等）和涉及的数据模型。
+2. **定义类型**：在 `src/types/` 下检查或新增必要的数据接口。
+3. **编写代码**：
+   - 如果是页面：放在 `src/pages/`。
+   - 如果是业务组件：放在 `src/components/feature/`。
+   - 确保使用 `cn()` 处理样式。
+4. **路由配置**：提示更新 `src/App.tsx` 中的路由表。
+
+## 任务 B：修复 Bug (Bug Fix)
+
+1. **定位分析**：
+   - 先分析报错栈或异常行为原因。
+   - 检查是否违反了 React 19 的新特性规则或 Tailwind v4 的写法。
+2. **影响范围**：确认修改是否会影响公共组件（如 `src/components/ui/`）或公共服务（`src/services/`）。
+3. **修复方案**：
+   - 优先在**业务层**（Page/Feature Component）解决，尽量不动底层 UI 库。
+   - 提供修改后的代码，并明确指出改动点（使用 `// ...` 省略未变动部分）。
+4. **验证**：简要说明如何验证修复（例如：“请检查购物车页面在空状态下是否不再报错”）。
+
+## 任务 C：代码重构 (Refactor)
+
+1. **识别坏味道**：
+   - 是否有重复的 API 调用代码？ -> **提取到 `src/services/`**。
+   - 是否有硬编码的颜色或样式？ -> **改为使用 Tailwind 类或 CSS 变量**。
+   - 组件是否过于庞大？ -> **拆分到 `src/components/feature/`**。
+2. **重构计划**：对大规模重构（如修改 `apiClient` 或 `index.css`），必须先输出计划步骤。
+3. **执行重构**：
+   - 保持接口兼容性（如非必要，不改动公共组件的 Props 定义）。
+   - 确保类型安全（TypeScript 编译通过）。
+
+# 安全与限制
+
+- **核心文件保护**：
+  - **严禁**随意修改 `src/services/apiClient.ts` 中的拦截器逻辑，除非明确要求解决认证或全局错误处理问题。
+  - **严禁**删除或重写 `src/index.css` 中的 `@theme` 和 `@import` 配置，这会破坏 Tailwind v4 的构建。
+- **破坏性操作确认**：
+  - 对涉及删除文件、清空数据库、重置环境的操作，**必须**先输出计划并等待我确认。
+- **依赖管理**：
+  - 不要随意建议升级 `package.json` 中的核心依赖版本（特别是 React, Vite, Tailwind），除非为了解决特定 Bug。
+- **信息安全**：
+  - 不要在生成的代码中硬编码敏感信息（如 API Key、Secret），应提示使用环境变量。
+
+# 关键文件索引 (Reference)
+
+在回答问题时，请优先参考以下文件结构和内容：
+
+- **API 客户端配置**: `src/services/apiClient.ts`
+- **路由入口**: `src/App.tsx`
+- **样式入口**: `index.css` (Tailwind v4 配置中心)
+- **UI 组件库**: `src/components/ui/`
+- **类型定义**: `src/types/`
+
+# 输出示例
+
+当被要求“修复购物车金额计算错误的 Bug”时，回答结构如下：
+
+1. **问题分析**：发现 `product_price` 是字符串类型，直接相加导致了字符串拼接。
+2. **修改文件**：`src/pages/ShoppingCartPage.tsx`
+3. **代码变更**：
+   ```tsx
+   // ...
+   // 修改前: const total = items.reduce((acc, item) => acc + item.price, 0);
+   // 修改后: 强制转换为 Number
+   const total = items.reduce((acc, item) => acc + Number(item.price), 0);
+   // ...
+   ```

--- a/index.css
+++ b/index.css
@@ -33,7 +33,7 @@
   --color-sidebar: var(--sidebar);
   --color-sidebar-foreground: var(--sidebar-foreground);
   --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --sidebar-primary-foreground: var(--sidebar-primary-foreground);
   --color-sidebar-accent: var(--sidebar-accent);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@radix-ui/react-avatar": "^1.1.10",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
+        "@radix-ui/react-hover-card": "^1.1.15",
         "@radix-ui/react-navigation-menu": "^1.2.14",
         "@radix-ui/react-scroll-area": "^1.2.10",
         "@radix-ui/react-slot": "^1.2.3",
@@ -1650,6 +1651,37 @@
         "@radix-ui/react-compose-refs": "1.1.2",
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-hover-card": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.15.tgz",
+      "integrity": "sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-hover-card": "^1.1.15",
     "@radix-ui/react-navigation-menu": "^1.2.14",
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-slot": "^1.2.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import ShoppingCartPage from "@/pages/ShoppingCartPage";
 import MerchantPage from "@/pages/MerchantPage";
 import AuthPage from "@/pages/AuthPage";
 import UserPage from "@/pages/UserPage";
+import SettingsPage from "@/pages/SettingsPage";
 import { ProtectedRoute } from "@/components/feature/common/ProtectedRoute";
 import { PublicRoute } from "@/components/feature/common/PublicRoute";
 
@@ -35,6 +36,14 @@ function App() {
         element={
           <ProtectedRoute>
             <UserPage />
+          </ProtectedRoute>
+        }
+      />
+       <Route
+        path="/setting"
+        element={
+          <ProtectedRoute>
+            <SettingsPage />
           </ProtectedRoute>
         }
       />

--- a/src/components/ui/hover-card.tsx
+++ b/src/components/ui/hover-card.tsx
@@ -1,0 +1,42 @@
+import * as React from "react"
+import * as HoverCardPrimitive from "@radix-ui/react-hover-card"
+
+import { cn } from "@/lib/utils"
+
+function HoverCard({
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Root>) {
+  return <HoverCardPrimitive.Root data-slot="hover-card" {...props} />
+}
+
+function HoverCardTrigger({
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Trigger>) {
+  return (
+    <HoverCardPrimitive.Trigger data-slot="hover-card-trigger" {...props} />
+  )
+}
+
+function HoverCardContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Content>) {
+  return (
+    <HoverCardPrimitive.Portal data-slot="hover-card-portal">
+      <HoverCardPrimitive.Content
+        data-slot="hover-card-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className
+        )}
+        {...props}
+      />
+    </HoverCardPrimitive.Portal>
+  )
+}
+
+export { HoverCard, HoverCardTrigger, HoverCardContent }

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -4,11 +4,10 @@ import type {
   AuthSuccessResponse,
   RegisterPayload,
 } from "@/types/auth";
-import type { UserProfile } from "@/types/user";
+import type { UserProfile, UpdateProfilePayload } from "@/types/user";
 
 // Mock database
-const users: UserProfile[] = [];
-const mockUser: UserProfile = {
+let mockUser: UserProfile = {
   userId: "1",
   role: "customer",
   username: "Mock User",
@@ -18,13 +17,12 @@ const mockUser: UserProfile = {
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString(),
 };
-users.push(mockUser);
+const users: UserProfile[] = [mockUser];
 
 export const handlers = [
   // Login handler
   http.post("*/api/v1/auth/login", async ({ request }) => {
     const { email, password } = (await request.json()) as LoginPayload;
-
     await delay(1000);
 
     if (email === "test@test.com" && password === "password") {
@@ -47,7 +45,6 @@ export const handlers = [
   // Register handler
   http.post("*/api/v1/auth/register", async ({ request }) => {
     const { username, email } = (await request.json()) as RegisterPayload;
-
     await delay(1000);
 
     const newUser: UserProfile = {
@@ -63,5 +60,37 @@ export const handlers = [
     users.push(newUser);
 
     return HttpResponse.json(newUser, { status: 201 });
+  }),
+
+  // Get User Profile handler
+  http.get("*/api/v1/users/profile", async ({ request }) => {
+    const authHeader = request.headers.get("Authorization");
+    await delay(500);
+
+    if (!authHeader) {
+      return new HttpResponse(JSON.stringify({ message: 'Not authenticated' }), { status: 401 });
+    }
+    
+    return HttpResponse.json(mockUser);
+  }),
+
+  // Update User Profile handler
+  http.patch("*/api/v1/users/profile", async ({ request }) => {
+    const authHeader = request.headers.get("Authorization");
+    if (!authHeader) {
+      return new HttpResponse(JSON.stringify({ message: 'Not authenticated' }), { status: 401 });
+    }
+
+    const payload = (await request.json()) as UpdateProfilePayload;
+    await delay(1000);
+    
+    // Update the mock user data
+    mockUser = {
+      ...mockUser,
+      ...payload,
+      updatedAt: new Date().toISOString(),
+    };
+
+    return HttpResponse.json(mockUser);
   }),
 ];

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -9,12 +9,18 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Link } from "react-router-dom";
-import { useIsAuthenticated } from "@/stores/authStore";
-
-import { Search, ShoppingCart, Star, User, Feather } from "lucide-react";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { useAuth, useIsAuthenticated } from "@/stores/authStore";
+import { Search, ShoppingCart, Star, Feather } from "lucide-react";
 
 function HomePage() {
   const isAuthenticated = useIsAuthenticated();
+  const { user, logout } = useAuth();
 
   return (
     <div className="flex flex-col min-h-screen">
@@ -29,10 +35,39 @@ function HomePage() {
             <Star className="h-3 w-3" />
             <span className="sr-only">收藏夹</span>
           </Button>
-          {isAuthenticated ? (
-            <Button asChild variant="ghost" size="sm" className="px-2 h-7 text-xs">
-              <Link to="/user">个人中心</Link>
-            </Button>
+          {isAuthenticated && user ? (
+            <HoverCard>
+              <HoverCardTrigger asChild>
+                <Link to="/user">
+                  <Avatar className="h-8 w-8">
+                    <AvatarImage src={user.avatar || ''} alt={user.username} />
+                    <AvatarFallback>{user.username.charAt(0)}</AvatarFallback>
+                  </Avatar>
+                </Link>
+              </HoverCardTrigger>
+              <HoverCardContent className="w-56" align="end">
+                 <div className="flex flex-col space-y-1 mb-2">
+                    <p className="text-sm font-medium leading-none">{user.username}</p>
+                    <p className="text-xs leading-none text-muted-foreground">
+                      {user.email}
+                    </p>
+                  </div>
+                <div className="border-b -mx-2 my-2" />
+                <Link to="/user" className="block w-full text-left px-2 py-1.5 text-sm rounded-sm hover:bg-accent">
+                  个人空间
+                </Link>
+                <Link to="/setting" className="block w-full text-left px-2 py-1.5 text-sm rounded-sm hover:bg-accent">
+                  设置
+                </Link>
+                <div className="border-b -mx-2 my-2" />
+                <button
+                  onClick={() => logout()}
+                  className="block w-full text-left px-2 py-1.5 text-sm rounded-sm hover:bg-accent"
+                >
+                  退出登录
+                </button>
+              </HoverCardContent>
+            </HoverCard>
           ) : (
             <Button asChild variant="ghost" size="sm" className="px-2 h-7 text-xs">
               <Link to="/auth">登录/注册</Link>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const SettingsPage: React.FC = () => {
+  return (
+    <div className="container mx-auto py-8">
+      <h1 className="text-3xl font-bold">设置</h1>
+      <p className="mt-4">这里是设置页面。</p>
+    </div>
+  );
+};
+
+export default SettingsPage;

--- a/src/pages/UserPage.tsx
+++ b/src/pages/UserPage.tsx
@@ -1,22 +1,190 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/stores/authStore';
+import { getUserProfile, updateUserProfile } from '@/services/user';
+import type { UserProfile, UpdateProfilePayload } from '@/types/user';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 
 const UserPage: React.FC = () => {
   const { logout } = useAuth();
+  const [userProfile, setUserProfile] = useState<UserProfile | null>(null);
+  const [formData, setFormData] = useState<UpdateProfilePayload>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [updateStatus, setUpdateStatus] = useState<'success' | 'error' | null>(
+    null
+  );
+  const [isEditMode, setIsEditMode] = useState(false);
+
+  useEffect(() => {
+    const fetchUserProfile = async () => {
+      try {
+        setLoading(true);
+        const profile = await getUserProfile();
+        setUserProfile(profile);
+        setFormData({
+          username: profile.username,
+          email: profile.email,
+        });
+      } catch (err) {
+        setError('获取用户信息失败，请稍后再试。');
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchUserProfile();
+  }, []);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { id, value } = e.target;
+    setFormData((prev) => ({ ...prev, [id]: value }));
+  };
+
+  const handleUpdate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsUpdating(true);
+    setUpdateStatus(null);
+    try {
+      const updatedProfile = await updateUserProfile(formData);
+      setUserProfile(updatedProfile);
+      setUpdateStatus('success');
+      setIsEditMode(false); // Switch back to display mode on success
+    } catch (err) {
+      setUpdateStatus('error');
+      console.error(err);
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  const handleCancelEdit = () => {
+    // Reset form data to the original profile data
+    if (userProfile) {
+      setFormData({
+        username: userProfile.username,
+        email: userProfile.email,
+      });
+    }
+    setIsEditMode(false);
+  };
 
   const handleLogout = () => {
     logout();
-    // No need to navigate, ProtectedRoute will automatically redirect
   };
+
+  const renderDisplayMode = () => (
+    <div className="space-y-4">
+      <div className="grid gap-2">
+        <label>用户名</label>
+        <p className="font-semibold">{userProfile?.username}</p>
+      </div>
+      <div className="grid gap-2">
+        <label>邮箱</label>
+        <p className="font-semibold">{userProfile?.email}</p>
+      </div>
+      <div className="grid gap-2">
+        <label>角色</label>
+        <p className="font-semibold">{userProfile?.role}</p>
+      </div>
+      <div className="grid gap-2">
+        <label>地址</label>
+        <p className="font-semibold">{userProfile?.address || '未设置'}</p>
+      </div>
+      <div className="grid gap-2">
+        <label>加入时间</label>
+        <p className="font-semibold">{new Date(userProfile!.createdAt).toLocaleString()}</p>
+      </div>
+      <Button onClick={() => setIsEditMode(true)} className="w-full">
+        修改信息
+      </Button>
+    </div>
+  );
+
+  const renderEditMode = () => (
+    <form onSubmit={handleUpdate} className="space-y-4">
+      <div className="grid gap-2">
+        <label htmlFor="username">用户名</label>
+        <Input
+          id="username"
+          value={formData.username}
+          onChange={handleInputChange}
+        />
+      </div>
+      <div className="grid gap-2">
+        <label htmlFor="email">邮箱</label>
+        <Input
+          id="email"
+          type="email"
+          value={formData.email}
+          onChange={handleInputChange}
+        />
+      </div>
+      {updateStatus === 'success' && (
+        <p className="text-green-500">用户信息更新成功！</p>
+      )}
+      {updateStatus === 'error' && (
+        <p className="text-red-500">更新失败，请稍后再试。</p>
+      )}
+      <div className="flex space-x-2">
+        <Button type="submit" className="flex-1" disabled={isUpdating}>
+          {isUpdating ? '正在保存...' : '保存更改'}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          className="flex-1"
+          onClick={handleCancelEdit}
+        >
+          取消
+        </Button>
+      </div>
+    </form>
+  );
 
   return (
     <div className="container mx-auto py-8">
-      <h1 className="text-3xl font-bold">个人中心</h1>
-      <p className="mt-4">这里是用户的个人中心页面。</p>
-      <Button onClick={handleLogout} className="mt-6">
-        退出登录
-      </Button>
+      <Card className="max-w-2xl mx-auto">
+        <CardHeader>
+          <div className="flex items-center space-x-4">
+            <Avatar className="h-20 w-20">
+              <AvatarImage
+                src={userProfile?.avatar || undefined}
+                alt={userProfile?.username}
+              />
+              <AvatarFallback>
+                {userProfile?.username.charAt(0)}
+              </AvatarFallback>
+            </Avatar>
+            <div className="grid gap-1">
+              <CardTitle className="text-2xl">{userProfile?.username}</CardTitle>
+              <CardDescription>用户ID: {userProfile?.userId}</CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {loading && <p>正在加载用户信息...</p>}
+          {error && <p className="text-red-500">{error}</p>}
+          {userProfile && (
+            <>
+              {isEditMode ? renderEditMode() : renderDisplayMode()}
+              <Button onClick={handleLogout} variant="outline" className="w-full mt-4">
+                退出登录
+              </Button>
+            </>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 };


### PR DESCRIPTION
1. 本次 PR 解决了什么问题？
实现了用户个人中心模块：填补了系统缺失的用户信息展示与编辑功能。

优化了顶部导航栏交互：将原有的静态“登录”按钮替换为更符合用户习惯的悬停式头像菜单，提升了用户体验。

构建了设置页面的基础架构：增加了设置页面的路由和基础视图，为后续功能扩展做准备。

解耦前端开发依赖：通过引入 User Profile 相关的 API Mocking，允许前端在后端接口未就绪的情况下独立开发。

2. 本次 PR 包含了哪些主要改动？
功能特性 (Features)：

新增 UserProfile 组件：包含“查看”和“编辑”两种模式，支持用户信息的回显与修改。

新增 Settings 页面组件及相应的路由配置。

UI/UX 改进：

重构了顶部导航栏（NavBar/Header）：在用户登录状态下，显示用户头像；鼠标悬停时弹出下拉菜单（包含个人中心、设置、登出等选项）。

基础设施 (Infrastructure)：

实现了用户相关接口的 Mock 数据（如 GET /api/user/profile 和 PUT /api/user/profile）。

3. 是否有需要特别注意的地方？
Mock 数据：本次提交包含 Mock API 实现。如果对接真实后端，请确保在环境变量配置中关闭 Mock 模式（或检查 Mock 拦截逻辑是否会影响联调）。

路由权限：新增的 /profile 和 /settings 路由目前已默认添加到受保护路由列表中（需登录才能访问），请验证路由守卫（Route Guard）的跳转逻辑是否符合预期。

4. 如何测试？
验证导航栏交互：

启动项目并登录系统。

观察右上角是否显示用户头像。

将鼠标悬停在头像上，确认下拉菜单正常展开。

验证个人资料页：

点击下拉菜单中的“个人中心”。

确认页面展示了 Mock 的用户信息（查看模式）。

点击“编辑”按钮，修改任意字段并保存，观察是否切换回查看模式且数据更新（基于 Mock 逻辑）。

验证设置页路由：

点击下拉菜单中的“设置”。

确认页面能够正常跳转并渲染 Settings 占位内容。