### PR TITLE
feat: settings page progress

### DIFF
--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,27 @@
+import * as React from "react"
+import * as SwitchPrimitives from "@radix-ui/react-switch"
+
+import { cn } from "@/lib/utils"
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      className
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
+      )}
+    />
+  </SwitchPrimitives.Root>
+))
+Switch.displayName = SwitchPrimitives.Root.displayName
+
+export { Switch }

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,10 +1,74 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { Switch } from "@/components/ui/switch";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 
 const SettingsPage: React.FC = () => {
+  const [notificationsEnabled, setNotificationsEnabled] = useState(true);
+  // Initialize dark mode state based on document class or system preference could be added here
+  const [isDarkMode, setIsDarkMode] = useState(false);
+
+  useEffect(() => {
+    // Check initial state
+    const isDark = document.documentElement.classList.contains('dark');
+    setIsDarkMode(isDark);
+  }, []);
+
+  const toggleDarkMode = (checked: boolean) => {
+    setIsDarkMode(checked);
+    if (checked) {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  };
+
   return (
-    <div className="container mx-auto py-8">
-      <h1 className="text-3xl font-bold">设置</h1>
-      <p className="mt-4">这里是设置页面。</p>
+    <div className="container mx-auto py-8 px-4 max-w-2xl">
+      <h1 className="text-3xl font-bold mb-8">设置</h1>
+      
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>通用设置</CardTitle>
+            <CardDescription>管理您的应用显示和通知偏好。</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="flex items-center justify-between space-x-2">
+              <div className="flex flex-col space-y-1">
+                <span className="text-sm font-medium leading-none">系统通知</span>
+                <span className="text-sm text-muted-foreground">
+                  启用或禁用系统级推送通知。
+                </span>
+              </div>
+              <Switch 
+                checked={notificationsEnabled}
+                onCheckedChange={setNotificationsEnabled}
+                aria-label="Toggle notifications"
+              />
+            </div>
+            
+            <div className="flex items-center justify-between space-x-2">
+              <div className="flex flex-col space-y-1">
+                <span className="text-sm font-medium leading-none">暗黑模式</span>
+                <span className="text-sm text-muted-foreground">
+                   切换应用程序的明暗主题风格。
+                </span>
+              </div>
+              <Switch 
+                checked={isDarkMode}
+                onCheckedChange={toggleDarkMode}
+                aria-label="Toggle dark mode"
+              />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
1. 本次 PR 解决了什么问题？
实现了应用设置页面，允许用户管理全局偏好。
引入了 Switch 开关组件，丰富了基础 UI 组件库。
2. 本次 PR 包含了哪些主要改动？
新页面：创建了 src/pages/SettingsPage.tsx，包含“通用设置”卡片。
实现了“系统通知”开关的状态管理（目前仅前端状态）。
实现了“暗黑模式”开关，支持实时切换 document 的 dark 类名以控制主题。
新组件：创建了 src/components/ui/switch.tsx，基于 @radix-ui/react-switch 封装了标准的开关组件。
依赖：使用了 lucide-react (图标) 和 react hooks (useState, useEffect)。
3. 是否有需要特别注意的地方？
暗黑模式的持久化目前尚未对接后端或本地存储（LocalStorage），刷新后会重置。
确保项目已安装 @radix-ui/react-switch 依赖。
4. 如何测试？
导航至 /settings 路由（或通过应用内导航进入设置页）。
点击“系统通知”开关，确认开关状态流畅切换。
点击“暗黑模式”开关：
开启时，页面背景及组件应立即切换为深色样式（前提是已配置 Tailwind dark 模式）。
关闭时，恢复浅色样式。