### PR TITLE
refactor: Update environment variable check and refine authentication…

### DIFF
--- a/src/components/feature/ common/Navigation-Manu.tsx
+++ b/src/components/feature/ common/Navigation-Manu.tsx
@@ -2,7 +2,6 @@
 
 import * as React from "react";
 import { Link } from "react-router-dom";
-import { CircleCheckIcon, CircleHelpIcon, CircleIcon } from "lucide-react";
 
 import {
   NavigationMenu,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,7 +5,7 @@ import { BrowserRouter } from "react-router-dom";
 import "../index.css"
 
 async function enableMocking() {
-  if (process.env.NODE_ENV !== 'development') {
+  if (import.meta.env.MODE !== 'development') {
     return;
   }
  

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,8 +1,8 @@
 import { http, HttpResponse, delay } from "msw";
 import type {
-  LoginPayload,
   AuthSuccessResponse,
   RegisterPayload,
+  PasswordLoginPayload,
 } from "@/types/auth";
 import type { UserProfile, UpdateProfilePayload } from "@/types/user";
 
@@ -22,7 +22,7 @@ const users: UserProfile[] = [mockUser];
 export const handlers = [
   // Login handler
   http.post("*/api/v1/auth/login", async ({ request }) => {
-    const { email, password } = (await request.json()) as LoginPayload;
+    const { email, password } = (await request.json()) as PasswordLoginPayload;
     await delay(1000);
 
     if (email === "test@test.com" && password === "password") {

--- a/src/services/auth.test.ts
+++ b/src/services/auth.test.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest/globals" />
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { login, register, refreshToken, logout } from './auth';
 import type {
   PasswordLoginPayload,
@@ -17,7 +17,7 @@ vi.mock('./apiClient', () => ({
 }));
 
 // Cast the mocked apiClient.post to a Mock type for easier testing
-const mockApiClientPost = apiClient.post as vi.Mock;
+const mockApiClientPost = apiClient.post as Mock;
 
 describe('auth service', () => {
   beforeEach(() => {

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import type { UserProfile } from "@/types/user";
 import { login as loginService, register as registerService } from "@/services/auth";
-import type { LoginPayload, RegisterPayload, AuthSuccessResponse } from "@/types/auth";
+import type { LoginPayload, RegisterPayload } from "@/types/auth";
 
 interface AuthState {
   user: UserProfile | null;


### PR DESCRIPTION
### 1. 本次 PR 解决了什么问题？
- 修复了项目部署到 Vercel 时因 TypeScript 检查报错导致构建失败的问题。
- 解决了代码中存在的未使用变量、类型定义缺失以及环境变量访问方式不兼容等 Lint 错误。
### 2. 本次 PR 包含了哪些主要改动？
- **清理未使用代码**：在 [src/components/feature/ common/Navigation-Manu.tsx](cci:7://file:///Users/ocean/frontend/phoenix/src/components/feature/%20common/Navigation-Manu.tsx:0:0-0:0) 中移除了未使用的 `lucide-react` 图标导入；在 [src/stores/authStore.ts](cci:7://file:///Users/ocean/frontend/phoenix/src/stores/authStore.ts:0:0-0:0) 中移除了未使用的 [AuthSuccessResponse](cci:2://file:///Users/ocean/frontend/phoenix/src/types/auth.ts:21:0-27:1) 类型导入。
- **修复环境配置**：在 [src/main.tsx](cci:7://file:///Users/ocean/frontend/phoenix/src/main.tsx:0:0-0:0) 中将 `process.env.NODE_ENV` 替换为 `import.meta.env.MODE`，以正确适配 Vite 的环境变量处理方式。
- **修正类型定义**：
    - 在 [src/mocks/handlers.ts](cci:7://file:///Users/ocean/frontend/phoenix/src/mocks/handlers.ts:0:0-0:0) 中显式引入并使用 [PasswordLoginPayload](cci:2://file:///Users/ocean/frontend/phoenix/src/types/auth.ts:7:0-11:1) 类型，修复了原 [LoginPayload](cci:2://file:///Users/ocean/frontend/phoenix/src/types/auth.ts:19:0-19:72) 联合类型导致的 `password` 属性访问报错。
    - 在 [src/services/auth.test.ts](cci:7://file:///Users/ocean/frontend/phoenix/src/services/auth.test.ts:0:0-0:0) 中引入 [Mock](cci:1://file:///Users/ocean/frontend/phoenix/src/main.tsx:6:0-16:1) 类型接口，修复了 `vi.Mock` 命名空间不存在的类型错误。
### 3. 是否有需要特别注意的地方？
- 无。本次改动主要为工程化配置和类型修复，不涉及业务逻辑变更。
### 4. 如何测试？
- 1. 在本地终端执行 `npm run build`
- 2. 确认构建过程顺利完成，且控制台未输出 typescript 错误 (error TSxxxx)
- 3. (可选) 重新推送到远程分支，查看 Vercel 部署状态是否转为 Success