### PR TITLE
Feature/GitHub actions ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20' # Or your preferred Node.js version
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Run build
+      run: npm run build
+
+    - name: Run lint
+      run: npm run lint
+
+    - name: Run type check
+      run: npm run type-check
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,7 @@ jobs:
     - name: Run type check
       run: npm run type-check
 
+    - name: Run build
+      run: npm run build
+      env:
+        DATABASE_URL: ${{ secrets.DATABASE_URL }}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "type-check": "tsc --noEmit",
     "preview": "vite preview",
     "test": "vitest"
   },


### PR DESCRIPTION
推送到仓库后：
队友发起 PR。
GitHub Actions 会立即启动，运行构建。
如果构建失败：
PR 页面会显示 Build Check / build (pull_request) — Failing。
队友点击旁边的 Details，会跳转到 GitHub 自己的 Actions 页面，能够完整看到哪一行代码导致了报错。
Vercel 依然会尝试构建（并可能失败），但队友不再需要关心 Vercel 的报错，只要看 GitHub Actions 的日志修好 bug 即可。