### PR TITLE
feat: Implement address management page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-avatar": "^1.1.10",
+        "@radix-ui/react-checkbox": "^1.3.3",
+        "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-hover-card": "^1.1.15",
         "@radix-ui/react-label": "^2.1.8",
@@ -1533,6 +1535,36 @@
         "@radix-ui/react-use-callback-ref": "1.1.1",
         "@radix-ui/react-use-is-hydrated": "0.1.0",
         "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   "dependencies": {
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.10",
+    "@radix-ui/react-checkbox": "^1.3.3",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-hover-card": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import AuthPage from "@/pages/AuthPage";
 import UserPage from "@/pages/UserPage";
 import SettingsPage from "@/pages/SettingsPage";
 import OrdersPage from "@/pages/OrdersPage";
+import AddressPage from "@/pages/AddressPage";
 import { ProtectedRoute } from "@/components/feature/common/ProtectedRoute";
 import { PublicRoute } from "@/components/feature/common/PublicRoute";
 
@@ -62,6 +63,14 @@ function App() {
         element={
           <ProtectedRoute>
             <OrdersPage />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/address"
+        element={
+          <ProtectedRoute>
+            <AddressPage />
           </ProtectedRoute>
         }
       />

--- a/src/components/ui/badge.ts
+++ b/src/components/ui/badge.ts
@@ -1,0 +1,23 @@
+import { cva } from "class-variance-authority"
+
+export const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export * from "./badge.tsx"

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,27 +1,8 @@
 import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
+import { type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
-
-const badgeVariants = cva(
-  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
-  {
-    variants: {
-      variant: {
-        default:
-          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
-        secondary:
-          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        destructive:
-          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
-        outline: "text-foreground",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-    },
-  }
-)
+import { badgeVariants } from "./badge"
 
 export interface BadgeProps
   extends React.HTMLAttributes<HTMLDivElement>,
@@ -33,4 +14,4 @@ function Badge({ className, variant, ...props }: BadgeProps) {
   )
 }
 
-export { Badge, badgeVariants }
+export { Badge }

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,28 @@
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { Check } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn("flex items-center justify-center text-current")}
+    >
+      <Check className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+))
+Checkbox.displayName = CheckboxPrimitive.Root.displayName
+
+export { Checkbox }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,120 @@
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-neutral-500", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/src/pages/AddressPage.tsx
+++ b/src/pages/AddressPage.tsx
@@ -1,0 +1,378 @@
+import React, { useEffect, useState } from "react";
+import {
+  getAddressList,
+  createAddress,
+  updateAddress,
+  deleteAddress,
+  setDefaultAddress,
+} from "@/services/address";
+import type { Address, CreateAddressPayload } from "@/types/address";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+//   DialogTrigger, // Not used
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Badge } from "@/components/ui/badge";
+import { Plus, Pencil, Trash2, MapPin } from "lucide-react";
+// Import simple Toast
+import { Toast } from "@/components/ui/toast";
+
+export default function AddressPage() {
+  const [addresses, setAddresses] = useState<Address[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isEditMode, setIsEditMode] = useState(false);
+  const [currentAddressId, setCurrentAddressId] = useState<number | null>(null);
+  
+  // Toast State
+  const [toastState, setToastState] = useState<{ show: boolean; message: string }>({
+    show: false,
+    message: "",
+  });
+
+  // Form State
+  const [formData, setFormData] = useState<CreateAddressPayload>({
+    receiverName: "",
+    receiverPhone: "",
+    province: "",
+    city: "",
+    district: "",
+    detailAddress: "",
+    zipCode: "",
+    tag: "",
+    isDefault: false,
+  });
+
+  const showToast = (message: string) => {
+    setToastState({ show: true, message });
+  };
+
+  const closeToast = () => {
+    setToastState((prev) => ({ ...prev, show: false }));
+  };
+
+  const fetchAddresses = async () => {
+    setLoading(true);
+    try {
+      const data = await getAddressList();
+      // Sort: Default address first
+      const sorted = [...data].sort((a, b) =>
+        a.isDefault === b.isDefault ? 0 : a.isDefault ? -1 : 1
+      );
+      setAddresses(sorted);
+    } catch (error) {
+      console.error("Failed to fetch addresses", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchAddresses();
+  }, []);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { id, value } = e.target;
+    setFormData((prev) => ({ ...prev, [id]: value }));
+  };
+
+  const handleCheckboxChange = (checked: boolean) => {
+      setFormData((prev) => ({ ...prev, isDefault: checked }));
+  }
+
+  const resetForm = () => {
+    setFormData({
+      receiverName: "",
+      receiverPhone: "",
+      province: "",
+      city: "",
+      district: "",
+      detailAddress: "",
+      zipCode: "",
+      tag: "",
+      isDefault: false,
+    });
+    setIsEditMode(false);
+    setCurrentAddressId(null);
+  };
+
+  const openAddDialog = () => {
+    resetForm();
+    setIsDialogOpen(true);
+  };
+
+  const openEditDialog = (address: Address) => {
+    setFormData({
+      receiverName: address.receiverName,
+      receiverPhone: address.receiverPhone,
+      province: address.province,
+      city: address.city,
+      district: address.district,
+      detailAddress: address.detailAddress,
+      zipCode: address.zipCode,
+      tag: address.tag,
+      isDefault: address.isDefault,
+    });
+    setIsEditMode(true);
+    setCurrentAddressId(address.id);
+    setIsDialogOpen(true);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      if (isEditMode && currentAddressId) {
+        await updateAddress(currentAddressId, formData);
+        showToast("地址已更新");
+      } else {
+        await createAddress(formData);
+        showToast("新地址已添加");
+      }
+      setIsDialogOpen(false);
+      fetchAddresses();
+    } catch (error) {
+      console.error(error);
+      showToast("操作失败，请重试");
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    if (!confirm("确定要删除这个地址吗？")) return;
+    try {
+      await deleteAddress(id);
+      showToast("地址已删除");
+      fetchAddresses();
+    } catch (error) {
+        console.error(error);
+        showToast("删除失败");
+    }
+  };
+
+  const handleSetDefault = async (id: number) => {
+    try {
+      await setDefaultAddress(id);
+      showToast("默认地址已设置");
+      fetchAddresses();
+    } catch (error) {
+        console.error(error);
+        showToast("设置默认地址失败");
+    }
+  };
+
+  if (loading && addresses.length === 0) {
+      return <div className="p-8 text-center">加载中...</div>
+  }
+
+  return (
+    <div className="container mx-auto py-8 max-w-5xl">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-2xl font-bold flex items-center gap-2">
+          <MapPin className="h-6 w-6" /> 我的地址
+        </h1>
+        <Button onClick={openAddDialog}>
+          <Plus className="mr-2 h-4 w-4" /> 新增地址
+        </Button>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {addresses.map((address) => (
+          <Card
+            key={address.id}
+            className={`relative transition-all hover:shadow-md ${
+              address.isDefault ? "border-primary border-2 bg-primary/5" : ""
+            }`}
+          >
+
+            <CardHeader className="pb-2">
+              <div className="flex justify-between items-center">
+                 <Badge variant="outline">{address.tag}</Badge>
+                 {address.isDefault && <Badge>默认</Badge>}
+              </div>
+            </CardHeader>
+            <CardContent className="grid gap-1.5 text-sm pt-4">
+              <div className="flex items-start gap-2">
+                <span className="font-semibold min-w-[4rem] text-muted-foreground">收货人:</span>
+                <span className="font-medium">{address.receiverName}</span>
+              </div>
+              <div className="flex items-start gap-2">
+                <span className="font-semibold min-w-[4rem] text-muted-foreground">手机号码:</span>
+                <span className="font-medium">{address.receiverPhone}</span>
+              </div>
+              <div className="flex items-start gap-2">
+                 <span className="font-semibold min-w-[4rem] text-muted-foreground">所在地区:</span>
+                 <span className="font-medium">{address.province} {address.city} {address.district}</span>
+              </div>
+              <div className="flex items-start gap-2">
+                <span className="font-semibold min-w-[4rem] text-muted-foreground">详细地址:</span>
+                <span className="font-medium">{address.detailAddress}</span>
+              </div>
+               <div className="flex items-start gap-2">
+                <span className="font-semibold min-w-[4rem] text-muted-foreground">邮政编码:</span>
+                <span className="font-medium">{address.zipCode}</span>
+              </div>
+            </CardContent>
+            <CardFooter className="flex justify-between pt-2">
+                {!address.isDefault && (
+                    <Button variant="ghost" size="sm" onClick={() => handleSetDefault(address.id)}>
+                        设为默认
+                    </Button>
+                )}
+               <div className="flex gap-2 ml-auto">
+                  <Button variant="outline" size="sm" onClick={() => openEditDialog(address)}>
+                    <Pencil className="h-4 w-4" />
+                  </Button>
+                  <Button variant="outline" size="sm" className="text-red-500 hover:text-red-600" onClick={() => handleDelete(address.id)}>
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+               </div>
+            </CardFooter>
+          </Card>
+        ))}
+        {addresses.length === 0 && !loading && (
+            <div className="col-span-full text-center py-12 text-gray-500 border-2 border-dashed rounded-lg">
+                <p>暂无地址，请添加新地址</p>
+            </div>
+        )}
+      </div>
+
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogContent className="sm:max-w-[525px]">
+          <DialogHeader>
+            <DialogTitle>{isEditMode ? "编辑地址" : "新增地址"}</DialogTitle>
+            <DialogDescription>
+              请填写真实的收货信息以确保商品准确送达。
+            </DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleSubmit} className="grid gap-4 py-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="grid gap-2">
+                <Label htmlFor="receiverName">收货人姓名</Label>
+                <Input
+                  id="receiverName"
+                  value={formData.receiverName}
+                  onChange={handleInputChange}
+                  required
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="receiverPhone">手机号码</Label>
+                <Input
+                  id="receiverPhone"
+                  value={formData.receiverPhone}
+                  onChange={handleInputChange}
+                  required
+                />
+              </div>
+            </div>
+            
+             <div className="grid grid-cols-3 gap-2">
+              <div className="grid gap-2">
+                <Label htmlFor="province">省份</Label>
+                 <Input
+                  id="province"
+                  placeholder="省"
+                  value={formData.province}
+                  onChange={handleInputChange}
+                  required
+                />
+              </div>
+               <div className="grid gap-2">
+                <Label htmlFor="city">城市</Label>
+                 <Input
+                  id="city"
+                  placeholder="市"
+                  value={formData.city}
+                  onChange={handleInputChange}
+                  required
+                />
+              </div>
+               <div className="grid gap-2">
+                <Label htmlFor="district">区/县</Label>
+                 <Input
+                  id="district"
+                  placeholder="区"
+                  value={formData.district}
+                  onChange={handleInputChange}
+                  required
+                />
+              </div>
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="detailAddress">详细地址</Label>
+              <Input
+                id="detailAddress"
+                placeholder="街道门牌、楼层房间号等信息"
+                value={formData.detailAddress}
+                onChange={handleInputChange}
+                required
+              />
+            </div>
+            
+            <div className="grid grid-cols-2 gap-4">
+                 <div className="grid gap-2">
+                    <Label htmlFor="zipCode">邮政编码</Label>
+                    <Input
+                        id="zipCode"
+                        value={formData.zipCode}
+                        onChange={handleInputChange}
+                        required
+                    />
+                </div>
+                 <div className="grid gap-2">
+                    <Label htmlFor="tag">地址标签</Label>
+                    <Input
+                        id="tag"
+                        placeholder="例如：家、公司"
+                        value={formData.tag}
+                        onChange={handleInputChange}
+                        required
+                    />
+                </div>
+            </div>
+            
+            <div className="flex items-center space-x-2 mt-2">
+                <Checkbox 
+                    id="isDefault" 
+                    checked={formData.isDefault}
+                    onCheckedChange={(checked) => handleCheckboxChange(checked as boolean)}
+                />
+                <label
+                    htmlFor="isDefault"
+                    className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                >
+                    设为默认地址
+                </label>
+            </div>
+
+            <DialogFooter className="mt-4">
+              <Button type="submit">{isEditMode ? "保存此地址" : "保存并使用"}</Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+      
+      <Toast 
+        message={toastState.message}
+        show={toastState.show}
+        onClose={closeToast}
+      />
+    </div>
+  );
+}

--- a/src/pages/AddressPage.tsx
+++ b/src/pages/AddressPage.tsx
@@ -11,10 +11,8 @@ import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
-  CardDescription,
   CardFooter,
   CardHeader,
-  CardTitle,
 } from "@/components/ui/card";
 import {
   Dialog,

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -150,6 +150,9 @@ function HomePage() {
                 <Link to="/user" className="block w-full text-left px-2 py-1.5 text-sm rounded-sm hover:bg-accent">
                   个人空间
                 </Link>
+                <Link to="/address" className="block w-full text-left px-2 py-1.5 text-sm rounded-sm hover:bg-accent">
+                    我的地址
+                </Link>
                 <Link to="/setting" className="block w-full text-left px-2 py-1.5 text-sm rounded-sm hover:bg-accent">
                   设置
                 </Link>

--- a/src/services/address.ts
+++ b/src/services/address.ts
@@ -1,33 +1,39 @@
-import {
-  type Address,
-  type CreateAddressPayload,
-  type UpdateAddressPayload,
-} from "@/types/address";
 import apiClient, { type ApiError } from "./apiClient";
+import type { Address, CreateAddressPayload, UpdateAddressPayload } from "@/types/address";
+
+export interface GenericResponse<T> {
+  code: number;
+  message: string;
+  data: T;
+}
 
 /**
- * @service POST /api/v1/addresses
- * @description Create a user address.
+ * @service GET /api/v1/addresses
+ * @description 获取当前用户地址列表
  */
-export const createAddress = async (
-  payload: CreateAddressPayload
-): Promise<Address> => {
+export const getAddressList = async (): Promise<Address[]> => {
   try {
-    const response = await apiClient.post<Address>("/api/v1/addresses", payload);
-    return response.data;
+    const response = await apiClient.get<GenericResponse<Address[]>>("/api/v1/addresses");
+    if (response.data && 'data' in response.data && 'code' in response.data) {
+        return response.data.data;
+    }
+    return response.data as unknown as Address[];
   } catch (err) {
     throw err as ApiError;
   }
 };
 
 /**
- * @service GET /api/v1/addresses
- * @description Get the current user's address list.
+ * @service POST /api/v1/addresses
+ * @description 创建一个用户地址
  */
-export const getAddressList = async (): Promise<Address[]> => {
+export const createAddress = async (payload: CreateAddressPayload): Promise<Address> => {
   try {
-    const response = await apiClient.get<Address[]>("/api/v1/addresses");
-    return response.data;
+    const response = await apiClient.post<GenericResponse<Address>>("/api/v1/addresses", payload);
+     if (response.data && 'data' in response.data && 'code' in response.data) {
+        return response.data.data;
+    }
+    return response.data as unknown as Address;
   } catch (err) {
     throw err as ApiError;
   }
@@ -35,18 +41,15 @@ export const getAddressList = async (): Promise<Address[]> => {
 
 /**
  * @service PUT /api/v1/addresses/{addressId}
- * @description Update a user address.
+ * @description 更新用户的某个地址
  */
-export const updateAddress = async (
-  addressId: number,
-  payload: UpdateAddressPayload
-): Promise<Address> => {
+export const updateAddress = async (addressId: number, payload: UpdateAddressPayload): Promise<Address> => {
   try {
-    const response = await apiClient.put<Address>(
-      `/api/v1/addresses/${addressId}`,
-      payload
-    );
-    return response.data;
+    const response = await apiClient.put<GenericResponse<Address>>(`/api/v1/addresses/${addressId}`, payload);
+     if (response.data && 'data' in response.data && 'code' in response.data) {
+        return response.data.data;
+    }
+    return response.data as unknown as Address;
   } catch (err) {
     throw err as ApiError;
   }
@@ -54,14 +57,11 @@ export const updateAddress = async (
 
 /**
  * @service PATCH /api/v1/addresses/{id}/default
- * @description Set an address as default.
+ * @description 将地址设置为默认地址
  */
-export const setDefaultAddress = async (id: number): Promise<Address> => {
+export const setDefaultAddress = async (id: number): Promise<void> => {
   try {
-    const response = await apiClient.patch<Address>(
-      `/api/v1/addresses/${id}/default`
-    );
-    return response.data;
+    await apiClient.patch(`/api/v1/addresses/${id}/default`);
   } catch (err) {
     throw err as ApiError;
   }
@@ -69,14 +69,11 @@ export const setDefaultAddress = async (id: number): Promise<Address> => {
 
 /**
  * @service DELETE /api/v1/addresses/{id}
- * @description Delete a user address.
+ * @description 删除对应地址
  */
-export const deleteAddress = async (id: number): Promise<{ message: string }> => {
-  try {
-    const response = await apiClient.delete<{ message: string }>(
-      `/api/v1/addresses/${id}`
-    );
-    return response.data;
+export const deleteAddress = async (id: number): Promise<void> => {
+   try {
+    await apiClient.delete(`/api/v1/addresses/${id}`);
   } catch (err) {
     throw err as ApiError;
   }


### PR DESCRIPTION
### 1. 本次 PR 解决了什么问题？

- 实现了用户地址管理功能，允许用户添加、修改、删除和设置默认收货地址。

### 2. 本次 PR 包含了哪些主要改动？

- 新增 `src/pages/AddressPage.tsx` 页面，实现地址列表展示及 CRUD 操作。
- 新增 `src/services/address.ts` 处理地址相关 API 请求。
- 在 `src/App.tsx` 中注册 `/address` 路由。
- 在 `src/pages/HomePage.tsx` 用户下拉菜单中添加“我的地址”入口。
- 新增 UI 组件：`Dialog` (弹窗), `Checkbox` (复选框), `Badge` (徽标)。
- 安装 `@radix-ui/react-dialog` 和 `@radix-ui/react-checkbox` 依赖。

### 3. 是否有需要特别注意的地方？

- 依赖项更新：需要执行 `npm install` 安装新添加的 UI 组件依赖。

### 4. 如何测试？

1. 登录系统。
2. 点击右上角头像，选择“我的地址”。
3. 测试新建地址，填写表单并保存。
4. 测试编辑现有地址。
5. 测试设为默认地址功能。
6. 测试删除地址。