### PR TITLE
refactor: update user profile edit fields to nickname, phone, and avatar

### DIFF
--- a/apiDoc.json
+++ b/apiDoc.json
@@ -675,7 +675,7 @@
             "in": "header",
             "description": "用于用户身份认证的令牌。格式为 `Bearer <token>`，其中 `<token>` 是从登录或注册接口返回的 `accessToken`。所有受保护的接口都必须携带此请求头。",
             "required": true,
-            "example": "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzY29wZSI6InJlYWQgd3JpdGUgcHJvZmlsZSIsInRva2VuX3R5cGUiOiJhY2Nlc3NfdG9rZW4iLCJzdWIiOiJ0ZXN0IiwiaWF0IjoxNzY3MjczMTM5LCJleHAiOjE3NjcyNzQwMzl9.t_71lcuHkkmf3t-z1Vei9xAjY-o-yXw5ncn88XmBs0c",
+            "example": "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzY29wZSI6InJlYWQgd3JpdGUgcHJvZmlsZSIsInRva2VuX3R5cGUiOiJhY2Nlc3NfdG9rZW4iLCJzdWIiOiJ0ZXN0MSIsImlhdCI6MTc2NzM2NjAzMywiZXhwIjoxNzY3MzY2OTMzfQ.-QuIg3WQBaHDGR5l_7ecllQcWpW7nwY_2lJ1nKztdQg",
             "schema": {
               "type": "string"
             }
@@ -687,7 +687,47 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserProfile"
+                  "type": "object",
+                  "properties": {
+                    "username": {
+                      "type": "string"
+                    },
+                    "password": {
+                      "type": "string"
+                    },
+                    "email": {
+                      "type": "string"
+                    },
+                    "phone": {
+                      "type": "null"
+                    },
+                    "role": {
+                      "type": "string"
+                    },
+                    "avatar": {
+                      "type": "string"
+                    },
+                    "nickname": {
+                      "type": "null"
+                    }
+                  },
+                  "required": [
+                    "username",
+                    "password",
+                    "email",
+                    "phone",
+                    "role",
+                    "avatar",
+                    "nickname"
+                  ]
+                },
+                "example": {
+                  "username": "test1",
+                  "password": "$2a$10$TwZLnLvcgnRyvrdyt5P3jeayZQLl05alpLSuYcm7Wir/RHD.Hxedu",
+                  "email": "2840719908@qq.com",
+                  "phone": null,
+                  "avatar": "https://picsum.photos/seed/9WhLT8GS/1007/1111",
+                  "nickname": null
                 }
               }
             },
@@ -727,7 +767,7 @@
             "in": "header",
             "description": "用于用户身份认证的令牌。格式为 `Bearer <token>`，其中 `<token>` 是从登录或注册接口返回的 `accessToken`。所有受保护的接口都必须携带此请求头。",
             "required": true,
-            "example": "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzY29wZSI6InJlYWQgd3JpdGUgcHJvZmlsZSIsInRva2VuX3R5cGUiOiJhY2Nlc3NfdG9rZW4iLCJzdWIiOiJ0ZXN0IiwiaWF0IjoxNzY3MjczMTM5LCJleHAiOjE3NjcyNzQwMzl9.t_71lcuHkkmf3t-z1Vei9xAjY-o-yXw5ncn88XmBs0c",
+            "example": "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzY29wZSI6InJlYWQgd3JpdGUgcHJvZmlsZSIsInRva2VuX3R5cGUiOiJhY2Nlc3NfdG9rZW4iLCJzdWIiOiJ0ZXN0IiwiaWF0IjoxNzY3MzMxNjEyLCJleHAiOjE3NjczMzI1MTJ9.wVqrl6HFp6MU7wD1d-UUIGoTw7K99Cr6n9KCN76nxTA",
             "schema": {
               "type": "string"
             }
@@ -753,11 +793,20 @@
                     "type": "string",
                     "title": "头像",
                     "description": "若没有，则返回null"
+                  },
+                  "nickname": {
+                    "type": "string"
+                  },
+                  "phone": {
+                    "type": "string"
                   }
-                }
+                },
+                "required": [
+                  "phone"
+                ]
               },
               "example": {
-                "username": "test",
+                "username": "test1",
                 "email": "2840719908@qq.com",
                 "avatar": "https://picsum.photos/seed/9WhLT8GS/1007/1111"
               }
@@ -3364,26 +3413,6 @@
           "role"
         ]
       },
-      "UpdateProfilePayload": {
-        "type": "object",
-        "properties": {
-          "username": {
-            "type": "string",
-            "title": "用户名",
-            "description": "若无，则提交null"
-          },
-          "email": {
-            "type": "string",
-            "title": "邮箱",
-            "description": "若无，则提交null"
-          },
-          "avatar": {
-            "type": "string",
-            "title": "头像",
-            "description": "若无，则提交null"
-          }
-        }
-      },
       "ChangePasswordPayload": {
         "type": "object",
         "properties": {
@@ -3420,28 +3449,6 @@
         "required": [
           "email",
           "password",
-          "loginType"
-        ]
-      },
-      "EmailCodeLoginPayload": {
-        "type": "object",
-        "properties": {
-          "loginType": {
-            "type": "string",
-            "title": "登录方式"
-          },
-          "email": {
-            "type": "string",
-            "title": "邮箱"
-          },
-          "code": {
-            "type": "string",
-            "title": "验证码"
-          }
-        },
-        "required": [
-          "email",
-          "code",
           "loginType"
         ]
       },
@@ -3695,28 +3702,6 @@
           "userId",
           "isPaid",
           "isDelivered"
-        ]
-      },
-      "ApiArror": {
-        "type": "object",
-        "properties": {
-          "message": {
-            "type": "string",
-            "title": "错误消息"
-          },
-          "code": {
-            "type": "string",
-            "title": "机器码"
-          },
-          "status": {
-            "type": "string",
-            "title": "错误码"
-          }
-        },
-        "required": [
-          "message",
-          "code",
-          "status"
         ]
       }
     },

--- a/src/pages/UserPage.tsx
+++ b/src/pages/UserPage.tsx
@@ -32,8 +32,9 @@ const UserPage: React.FC = () => {
         const profile = await getUserProfile();
         setUserProfile(profile);
         setFormData({
-          username: profile.username,
-          email: profile.email,
+          nickname: profile.nickname || '',
+          phone: profile.phone || '',
+          avatar: profile.avatar || '',
         });
       } catch (err) {
         setError('获取用户信息失败，请稍后再试。');
@@ -80,8 +81,9 @@ const UserPage: React.FC = () => {
     // Reset form data to the original profile data
     if (userProfile) {
       setFormData({
-        username: userProfile.username,
-        email: userProfile.email,
+        nickname: userProfile.nickname || '',
+        phone: userProfile.phone || '',
+        avatar: userProfile.avatar || '',
       });
     }
     setIsEditMode(false);
@@ -93,28 +95,45 @@ const UserPage: React.FC = () => {
 
   const renderDisplayMode = () => (
     <div className="space-y-4">
+      <div className="flex items-center space-x-4 mb-6">
+        <label className="font-semibold min-w-16">头像</label>
+        <Avatar className="h-16 w-16">
+          <AvatarImage
+            src={userProfile?.avatar || undefined}
+            alt={userProfile?.nickname || userProfile?.username || '用户'}
+          />
+          <AvatarFallback>
+            {(userProfile?.nickname || userProfile?.username || 'U').charAt(0).toUpperCase()}
+          </AvatarFallback>
+        </Avatar>
+      </div>
+
       <div className="grid gap-2">
         <label>用户名</label>
-        <p className="font-semibold">{userProfile?.username || '未设置'}</p>
+        <p className="font-semibold text-gray-500">{userProfile?.username}</p>
+      </div>
+      <div className="grid gap-2">
+        <label>昵称</label>
+        <p className="font-semibold">{userProfile?.nickname || '未设置'}</p>
+      </div>
+      <div className="grid gap-2">
+        <label>手机号</label>
+        <p className="font-semibold">{userProfile?.phone || '未设置'}</p>
       </div>
       <div className="grid gap-2">
         <label>邮箱</label>
-        <p className="font-semibold">{userProfile?.email}</p>
+        <p className="font-semibold text-gray-500">{userProfile?.email}</p>
       </div>
-      <div className="grid gap-2">
+       <div className="grid gap-2">
         <label>角色</label>
-        <p className="font-semibold">{userProfile?.role}</p>
-      </div>
-      <div className="grid gap-2">
-        <label>地址</label>
-        <p className="font-semibold">{userProfile?.address || '未设置'}</p>
+        <p className="font-semibold text-gray-500">{userProfile?.role}</p>
       </div>
       <div className="grid gap-2">
         <label>加入时间</label>
-        <p className="font-semibold">{userProfile?.createdAt ? new Date(userProfile.createdAt).toLocaleString() : '未知'}</p>
+        <p className="font-semibold text-gray-500">{userProfile?.createdAt ? new Date(userProfile.createdAt).toLocaleString() : '未知'}</p>
       </div>
       <Button onClick={() => setIsEditMode(true)} className="w-full">
-        修改信息
+        修改个人信息
       </Button>
     </div>
   );
@@ -122,24 +141,34 @@ const UserPage: React.FC = () => {
   const renderEditMode = () => (
     <form onSubmit={handleUpdate} className="space-y-4">
       <div className="grid gap-2">
-        <label htmlFor="username">用户名</label>
+        <label htmlFor="avatar">头像 URL</label>
         <Input
-          id="username"
-          value={formData.username || ''}
+          id="avatar"
+          value={formData.avatar || ''}
           onChange={handleInputChange}
+          placeholder="请输入头像图片链接"
         />
       </div>
       <div className="grid gap-2">
-        <label htmlFor="email">邮箱</label>
+        <label htmlFor="nickname">昵称</label>
         <Input
-          id="email"
-          type="email"
-          value={formData.email || ''}
+          id="nickname"
+          value={formData.nickname || ''}
           onChange={handleInputChange}
+          placeholder="请输入昵称"
+        />
+      </div>
+      <div className="grid gap-2">
+        <label htmlFor="phone">手机号</label>
+        <Input
+          id="phone"
+          value={formData.phone || ''}
+          onChange={handleInputChange}
+          placeholder="请输入手机号"
         />
       </div>
       {updateStatus === 'success' && (
-        <p className="text-green-500">用户信息更新成功！</p>
+        <p className="text-green-500">此人信息更新成功！</p>
       )}
       {updateStatus === 'error' && (
         <p className="text-red-500">更新失败，请稍后再试。</p>

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -11,8 +11,10 @@ export interface UserProfile {
   userId?: string;
   role?: string;
   username?: string;
+  nickname?: string | null;
   avatar?: string | null;
   email: string;
+  phone?: string | null;
   address?: string | null;
   createdAt?: string;
   updatedAt?: string;
@@ -22,8 +24,8 @@ export interface UserProfile {
  * @description 更新用户个人资料时提交的数据体 (Payload)
  */
 export interface UpdateProfilePayload {
-  username?: string;
-  email?: string;
+  nickname?: string;
+  phone?: string;
   avatar?: string;
 }
 


### PR DESCRIPTION
### 1. 本次 PR 解决了什么问题？

- 重构了用户信息修改页面，使其支持修改头像、昵称和手机号，而不再是不允许修改的用户名和邮箱。
- 对应于最新的 API 文档变更。

### 2. 本次 PR 包含了哪些主要改动？

- **`src/types/user.ts`**:
    - `UserProfile` 接口新增 `nickname`, `phone` 字段。
    - `UpdateProfilePayload` 接口修改为仅包含 `nickname`, `phone`, `avatar`。
- **`src/pages/UserPage.tsx`**:
    - 用户展示部分新增了头像、昵称、手机号的显示。
    - 编辑模式下的表单改为修改头像链接、昵称和手机号。
    - 移除了对用户名和邮箱的编辑功能（这两项通常作为唯一标识，不可轻易修改）。

### 3. 如何测试？

1. 登录系统。
2. 进入“个人信息”页面。
3. 点击“修改个人信息”。
4. 尝试修改头像链接、昵称和手机号。
5. 保存并确认页面展示更新后的信息。